### PR TITLE
enable syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,4 +29,7 @@ excerpt_separator: "<!--excerpt-->"
 
 # Build settings
 markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 theme: minima


### PR DESCRIPTION
this should enable syntax highlighting when it builds the documentation.